### PR TITLE
Fix compilation error for sgxsdk-2.11 (#431)

### DIFF
--- a/core/shared/platform/linux-sgx/sgx_pthread.c
+++ b/core/shared/platform/linux-sgx/sgx_pthread.c
@@ -12,6 +12,9 @@
 #define TRACE_FUNC() os_printf("undefined %s\n", __FUNCTION__)
 #define TRACE_OCALL_FAIL() os_printf("ocall %s failed!\n", __FUNCTION__)
 
+#ifndef SGX_THREAD_LOCK_INITIALIZER /* defined since sgxsdk-2.11 */
+/* sgxsdk doesn't support pthread_rwlock related APIs until
+   version 2.11, we implement them by ourselves. */
 int ocall_pthread_rwlock_init(int *p_ret, void **rwlock, void *attr);
 
 int ocall_pthread_rwlock_destroy(int *p_ret, void **rwlock);
@@ -74,6 +77,7 @@ int pthread_rwlock_unlock(pthread_rwlock_t *rwlock)
     }
     return ret;
 }
+#endif /* end of SGX_THREAD_LOCK_INITIALIZER */
 
 #endif
 

--- a/core/shared/platform/linux-sgx/sgx_pthread.h
+++ b/core/shared/platform/linux-sgx/sgx_pthread.h
@@ -10,6 +10,9 @@
 extern "C" {
 #endif
 
+#ifndef SGX_THREAD_LOCK_INITIALIZER /* defined since sgxsdk-2.11 */
+/* sgxsdk doesn't support pthread_rwlock related APIs until
+   version 2.11, we implement them by ourselves. */
 typedef uintptr_t pthread_rwlock_t;
 
 int pthread_rwlock_init(pthread_rwlock_t *rwlock, void *attr);
@@ -18,6 +21,7 @@ int pthread_rwlock_destroy(pthread_rwlock_t *rwlock);
 int pthread_rwlock_wrlock(pthread_rwlock_t *rwlock);
 int pthread_rwlock_rdlock(pthread_rwlock_t *rwlock);
 int pthread_rwlock_unlock(pthread_rwlock_t *rwlock);
+#endif /* end of SGX_THREAD_LOCK_INITIALIZER */
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
sgxsdk-2.11 enable pthread_rwlock APIs support, and causes compilation
error. We use macro SGX_THREAD_LOCK_INITIALIZER to control it.